### PR TITLE
Resolve there is no package called ‘rmarkdown’

### DIFF
--- a/install.R
+++ b/install.R
@@ -1,1 +1,2 @@
+install.packages("rmarkdown")
 install.packages("jsonlite")


### PR DESCRIPTION
```
Error in loadNamespace(x) : there is no package called ‘rmarkdown’
Calls: loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
Execution halted
```

is a common errror when rendering Quarto documents with R code.